### PR TITLE
Hardening Firebase Rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -18,8 +18,7 @@
         ".validate": "newData.hasChildren(['title','description','author','date', 'score', 'image', 'publisher'])",
         "offers": {
           "$offer_id": {
-            ".write": "auth != null && newData.child('author').val() == auth.uid",
-            ".validate": "newData.hasChildren(['author', 'modality', 'exchange'])"
+            ".validate": "newData.hasChildren(['author', 'modality', 'exchange']) && newData.child('author').val() == auth.uid"
           }
         }
       }


### PR DESCRIPTION
Fixes #62
You can view the security issue in [this report](https://noless.io/report/-L7RT01XSjoGM_In4kkv/9a59c459-db6a-44cd-9efd-b5e7141540c0).

## Solution

I removed the rule ` ".write": "auth != null && newData.child('author').val() == auth.uid"` from `/books/$book_id/offers/$offer_id` since it was useless and instead, added the author check to the validation rule, because validation rules are not cascading.

An analysis on the fixed rules can be [seen here](https://noless.io/report/-L7RT3mVzhlpI-vWyTrW/90e1f2e0-fd33-47d7-9e0a-54c2953a99cd).